### PR TITLE
Release serialization resources (fixes #4774)

### DIFF
--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -560,6 +560,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
     WAIT UNTIL mv_free = lv_max UP TO 120 SECONDS.
     rt_files = mt_files.
+    FREE mt_files.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -224,7 +224,14 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       iv_language         = io_dot_abapgit->get_main_language( )
       ii_log              = ii_log
       iv_force_sequential = lv_force ).
-    APPEND LINES OF lt_found TO ct_files.
+      
+* transfer one by one and delete from original table as APPEND LINES OF
+* leads to doubling memory usage during execution of statement which
+* could result in SYSTEM_NO_ROLL dump
+    LOOP AT lt_found ASSIGNING <ls_found>.
+      APPEND <ls_found> TO ct_files.
+      DELETE lt_found.
+    ENDLOOP.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -131,6 +131,8 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
       ii_log            = li_log
       it_filter         = it_filter ).
 
+    FREE lo_serialize.
+
     IF li_log->count( ) > 0 AND iv_show_log = abap_true.
       zcl_abapgit_log_viewer=>show_log( li_log ).
     ENDIF.


### PR DESCRIPTION
Release serialization resources to prevent dump #4774 for export of large packages